### PR TITLE
Fix docs for CenterCrop and RandomCrop

### DIFF
--- a/torchvision/transforms.py
+++ b/torchvision/transforms.py
@@ -204,7 +204,7 @@ class CenterCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (w, h), a square crop (size, size) is
+            int instead of sequence like (h, w), a square crop (size, size) is
             made.
     """
 
@@ -275,7 +275,7 @@ class RandomCrop(object):
 
     Args:
         size (sequence or int): Desired output size of the crop. If size is an
-            int instead of sequence like (w, h), a square crop (size, size) is
+            int instead of sequence like (h, w), a square crop (size, size) is
             made.
         padding (int or sequence, optional): Optional padding on each border
             of the image. Default is 0, i.e no padding. If a sequence of length


### PR DESCRIPTION
Wrong order of dimensions In transforms.CenterCrop and transforms.RandomCrop:
Documentation says it should be (w, h), but it actually is (h, w).
Fixing docs to match the code